### PR TITLE
Treat frontend_cid cookie like frontend with vcl_fix

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -280,6 +280,9 @@ sub vcl_hash {
     if (req.http.X-Varnish-Esi-Access == "private" &&
             req.http.Cookie ~ "frontend=") {
         set req.hash += regsub(req.http.Cookie, "^.*?frontend=([^;]*);*.*$", "\1");
+        if (req.http.Cookie ~ "frontend_cid=") {
+            set req.hash += regsub(req.http.Cookie, "^.*?frontend_cid=([^;]*);*.*$", "\1");
+        }
         {{advanced_session_validation}}
     }
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -282,6 +282,9 @@ sub vcl_hash {
     if (req.http.X-Varnish-Esi-Access == "private" &&
             req.http.Cookie ~ "frontend=") {
         hash_data(regsub(req.http.Cookie, "^.*?frontend=([^;]*);*.*$", "\1"));
+        if (req.http.Cookie ~ "frontend_cid=") {
+            hash_data(regsub(req.http.Cookie, "^.*?frontend_cid=([^;]*);*.*$", "\1"));
+        }
         {{advanced_session_validation}}
 
     }

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -302,10 +302,13 @@ sub vcl_hash {
             req.http.Cookie ~ "frontend=") {
         std.log("hash_data - frontned cookie: " + regsub(req.http.Cookie, "^.*?frontend=([^;]*);*.*$", "\1"));
         hash_data(regsub(req.http.Cookie, "^.*?frontend=([^;]*);*.*$", "\1"));
+        if (req.http.Cookie ~ "frontend_cid=") {
+            std.log("hash_data - frontend_cid cookie: " + regsub(req.http.Cookie, "^.*?frontend_cid=([^;]*);*.*$", "\1"));
+            hash_data(regsub(req.http.Cookie, "^.*?frontend_cid=([^;]*);*.*$", "\1"));
+        }
         {{advanced_session_validation}}
-
     }
-    
+
     if (req.http.X-Varnish-Esi-Access == "customer_group" &&
             req.http.Cookie ~ "customer_group=") {
         hash_data(regsub(req.http.Cookie, "^.*?customer_group=([^;]*);*.*$", "\1"));


### PR DESCRIPTION
There are various issues / stack exchange posts about "add to basket"
buttons not working the first time someone presses them when using the vcl_fix
method and running with an https insecure_base_url via say
nginx:443->varnish->nginx.

These issues are happening because magento is sending a second
cookie, frontend_cid, under this configuration. The value of
frontend_cid is kept in $_SESSION and the cookie is validated when the
session is started.

This patch adds the frontend_cid cookie to hash_data on esi private
access the same as frontend cookie and appears to work.

NOTES:
- I haven't worried about the case when not using vcl_fix
- X-Varnish-Set-Cookie shows frontend_cid for me, as beresp only sends one cookie